### PR TITLE
Adds CMakeLists.txt and package.xml for ROS users

### DIFF
--- a/src/protobuf_comm/CMakeLists.txt
+++ b/src/protobuf_comm/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 2.8.7)
+project(protobuf_comm)
+
+find_package(Boost 1.46.1 REQUIRED thread system)
+find_package(OpenSSL REQUIRED)
+find_package(Protobuf REQUIRED)
+find_package(catkin REQUIRED)
+
+add_definitions("-std=c++0x")
+add_definitions("-DHAVE_LIBCRYPTO")
+
+include_directories(
+  ..
+  ${Boost_INCLUDE_DIRS}
+  ${OPENSSL_INCLUDE_DIR}
+  ${PROTOBUF_INCLUDE_DIRS}
+)
+
+catkin_package(
+  DEPENDS
+    Boost
+    OpenSSL
+    Protobuf
+  INCLUDE_DIRS
+    ..
+    ${Boost_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIR}
+    ${PROTOBUF_INCLUDE_DIRS}
+  LIBRARIES
+    protobuf_comm
+)
+
+set(PROTOBUF_COMM_SOURCES
+  client.cpp
+  crypto.cpp
+  message_register.cpp
+  peer.cpp
+  server.cpp
+)
+set(PROTOBUF_COMM_HEADERS
+  client.h
+  crypto.h
+  frame_header.h
+  message_register.h
+  peer.h
+  queue_entry.h
+  server.h
+  version.h
+)
+
+add_library(protobuf_comm SHARED ${PROTOBUF_COMM_SOURCES})
+target_link_libraries(protobuf_comm ${OPENSSL_LIBRARIES} ${Boost_LIBRARIES} ${PROTOBUF_LIBRARIES})
+
+file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/${PROJECT_NAME} )
+
+add_custom_target(${PROJECT_NAME}_copy_headers ALL)
+
+foreach(File ${PROTOBUF_COMM_HEADERS})
+  add_custom_command(TARGET ${PROJECT_NAME}_copy_headers POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${File} ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/${PROJECT_NAME}
+  )
+endforeach()
+ 
+install(
+  TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(FILES ${PROTOBUF_COMM_HEADERS}
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+

--- a/src/protobuf_comm/package.xml
+++ b/src/protobuf_comm/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package>
+  <name>protobuf_comm</name>
+  <version>0.0.1</version>
+  <description>
+    protobuf_comm:
+    Light-weight communication library for protobuf messages.
+    
+    Note: the recommended way to install protobuf_comm as a system library.
+    The library is ROS independent.
+    It has been given a package.xml and CMakeLists.txt for convenience.
+  </description>
+
+  <author email="niemueller@kbsg.rwth-aachen.de">Tim Niemueller</author>
+  <maintainer email="niemueller@kbsg.rwth-aachen.de">Tim Niemueller</maintainer>
+  <maintainer email="alexander.moriarty@brsu.de">Alexander Moriarty</maintainer>
+
+  <license>GPLv2</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+</package>


### PR DESCRIPTION
I have tested this on ROS Indigo using both:
- `catkin_make`
- `catkin build` (still in beta)

The only odd bits are the `..` in include_dirs, and the custom command to copy each header.
- The `add_custom_command` gets around the headers not being in `./include/${PROJECT_NAME}`
- The `..` is because the headers include the prefix `protobuf_comm`
